### PR TITLE
make variable separators

### DIFF
--- a/separators.go
+++ b/separators.go
@@ -1,6 +1,6 @@
 package objx
 
-const (
+var (
 	// PathSeparator is the character used to separate the elements
 	// of the keypath.
 	//


### PR DESCRIPTION
In some APIs, JSON keys are named like "title.subtitle", which conflicts with default objx separators. Is it possible to transform them into variables?