### PR TITLE
Drop old go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: go
 go:
-  - 1.4
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
   - 1.9
   - tip
 
 script:
-- go test $(go list ./... | grep -v /vendor/)
+- go test -race $(go list ./... | grep -v /vendor/)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 [![Build Status](https://travis-ci.org/stretchr/objx.svg?branch=master)](https://travis-ci.org/stretchr/objx)
 
   * Jump into the [API Documentation](http://godoc.org/github.com/stretchr/objx)
+
+**Supported go versions:** 1.7 - 1.9


### PR DESCRIPTION
We should do the same as testify (See https://github.com/stretchr/testify/commit/9ede17e9c007921759f6362fd2018812be57129)