### PR TITLE
Refactor tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,9 +3,6 @@ engines:
     enabled: true
   golint:
     enabled: true
-    checks:
-      GoLint/Comments/PackageComments:
-        enabled: false
   govet:
     enabled: true
 
@@ -13,3 +10,4 @@ exclude_patterns:
 - ".github/"
 - "vendor/"
 - "codegen/"
+- "doc.go"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,13 +15,16 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
   version = "v1.2.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "50e2495ec1af6e2f7ffb2f3551e4300d30357d7c7fe38ff6056469fa9cfb3673"
+  inputs-digest = "2d160a7dea4ffd13c6c31dab40373822f9d78c73beba016d662bef8f7a998876"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/accessors.go
+++ b/accessors.go
@@ -1,7 +1,6 @@
 package objx
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -28,7 +27,7 @@ var arrayAccesRegex = regexp.MustCompile(arrayAccesRegexString)
 //
 //    o.Get("books[1].chapters[2].title")
 func (m Map) Get(selector string) *Value {
-	rawObj := access(m, selector, nil, false, false)
+	rawObj := access(m, selector, nil, false)
 	return &Value{data: rawObj}
 }
 
@@ -43,21 +42,18 @@ func (m Map) Get(selector string) *Value {
 //
 //    o.Set("books[1].chapters[2].title","Time to Go")
 func (m Map) Set(selector string, value interface{}) Map {
-	access(m, selector, value, true, false)
+	access(m, selector, value, true)
 	return m
 }
 
 // access accesses the object using the selector and performs the
 // appropriate action.
-func access(current, selector, value interface{}, isSet, panics bool) interface{} {
+func access(current, selector, value interface{}, isSet bool) interface{} {
 	switch selector.(type) {
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		if array, ok := current.([]interface{}); ok {
 			index := intFromInterface(selector)
 			if index >= len(array) {
-				if panics {
-					panic(fmt.Sprintf("objx: Index %d is out of range. Slice only contains %d items.", index, len(array)))
-				}
 				return nil
 			}
 			return array[index]
@@ -87,11 +83,9 @@ func access(current, selector, value interface{}, isSet, panics bool) interface{
 				}
 			}
 		}
-
 		if curMap, ok := current.(Map); ok {
 			current = map[string]interface{}(curMap)
 		}
-
 		// get the object in question
 		switch current.(type) {
 		case map[string]interface{}:
@@ -104,27 +98,18 @@ func access(current, selector, value interface{}, isSet, panics bool) interface{
 		default:
 			current = nil
 		}
-
-		if current == nil && panics {
-			panic(fmt.Sprintf("objx: '%v' invalid on object.", selector))
-		}
-
 		// do we need to access the item of an array?
 		if index > -1 {
 			if array, ok := current.([]interface{}); ok {
 				if index < len(array) {
 					current = array[index]
 				} else {
-					if panics {
-						panic(fmt.Sprintf("objx: Index %d is out of range. Slice only contains %d items.", index, len(array)))
-					}
 					current = nil
 				}
 			}
 		}
-
 		if len(selSegs) > 1 {
-			current = access(current, selSegs[1], value, isSet, panics)
+			current = access(current, selSegs[1], value, isSet)
 		}
 	}
 	return current
@@ -157,7 +142,7 @@ func intFromInterface(selector interface{}) int {
 	case uint64:
 		value = int(selector.(uint64))
 	default:
-		panic("objx: array access argument is not an integer type (this should never happen)")
+		return 0
 	}
 	return value
 }

--- a/accessors.go
+++ b/accessors.go
@@ -50,27 +50,21 @@ func (m Map) Set(selector string, value interface{}) Map {
 // access accesses the object using the selector and performs the
 // appropriate action.
 func access(current, selector, value interface{}, isSet, panics bool) interface{} {
-
 	switch selector.(type) {
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-
 		if array, ok := current.([]interface{}); ok {
 			index := intFromInterface(selector)
-
 			if index >= len(array) {
 				if panics {
 					panic(fmt.Sprintf("objx: Index %d is out of range. Slice only contains %d items.", index, len(array)))
 				}
 				return nil
 			}
-
 			return array[index]
 		}
-
 		return nil
 
 	case string:
-
 		selStr := selector.(string)
 		selSegs := strings.SplitN(selStr, PathSeparator, 2)
 		thisSel := selSegs[0]
@@ -79,7 +73,6 @@ func access(current, selector, value interface{}, isSet, panics bool) interface{
 
 		if strings.Contains(thisSel, "[") {
 			arrayMatches := arrayAccesRegex.FindStringSubmatch(thisSel)
-
 			if len(arrayMatches) > 0 {
 				// Get the key into the map
 				thisSel = arrayMatches[1]
@@ -133,7 +126,6 @@ func access(current, selector, value interface{}, isSet, panics bool) interface{
 		if len(selSegs) > 1 {
 			current = access(current, selSegs[1], value, isSet, panics)
 		}
-
 	}
 	return current
 }

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -113,17 +113,6 @@ func TestAccessorsAccessSetInsideArray(t *testing.T) {
 	assert.Equal(t, "Underpants", access(current, "names[1].last", nil, false, true))
 }
 
-func TestAccessorsAccessSetFromArrayWithInt(t *testing.T) {
-	current := []interface{}{map[string]interface{}{"first": "Tyler", "last": "Bunnell"}, map[string]interface{}{"first": "Capitol", "last": "Bollocks"}}
-	one := access(current, 0, nil, false, false)
-	two := access(current, 1, nil, false, false)
-	three := access(current, 2, nil, false, false)
-
-	assert.Equal(t, "Tyler", one.(map[string]interface{})["first"])
-	assert.Equal(t, "Capitol", two.(map[string]interface{})["first"])
-	assert.Nil(t, three)
-}
-
 func TestAccessorsSet(t *testing.T) {
 	current := New(map[string]interface{}{"name": "Tyler"})
 

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -9,7 +9,13 @@ import (
 func TestAccessorsAccessGetSingleField(t *testing.T) {
 	current := Map{"name": "Tyler"}
 
-	assert.Equal(t, "Tyler", access(current, "name", nil, false, true))
+	assert.Equal(t, "Tyler", current.Get("name").Data())
+}
+
+func TestAccessorsAccessGetSingleFieldInt(t *testing.T) {
+	current := Map{"name": 10}
+
+	assert.Equal(t, 10, current.Get("name").Data())
 }
 
 func TestAccessorsAccessGetDeep(t *testing.T) {
@@ -20,8 +26,8 @@ func TestAccessorsAccessGetDeep(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "Tyler", access(current, "name.first", nil, false, true))
-	assert.Equal(t, "Bunnell", access(current, "name.last", nil, false, true))
+	assert.Equal(t, "Tyler", current.Get("name.first").Data())
+	assert.Equal(t, "Bunnell", current.Get("name.last").Data())
 }
 
 func TestAccessorsAccessGetDeepDeep(t *testing.T) {
@@ -35,7 +41,7 @@ func TestAccessorsAccessGetDeepDeep(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, 4, access(current, "one.two.three.four", nil, false, true))
+	assert.Equal(t, 4, current.Get("one.two.three.four").Data())
 }
 
 func TestAccessorsAccessGetInsideArray(t *testing.T) {
@@ -52,14 +58,12 @@ func TestAccessorsAccessGetInsideArray(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "Tyler", access(current, "names[0].first", nil, false, true))
-	assert.Equal(t, "Bunnell", access(current, "names[0].last", nil, false, true))
-	assert.Equal(t, "Capitol", access(current, "names[1].first", nil, false, true))
-	assert.Equal(t, "Bollocks", access(current, "names[1].last", nil, false, true))
-	assert.Panics(t, func() {
-		access(current, "names[2]", nil, false, true)
-	})
-	assert.Nil(t, access(current, "names[2]", nil, false, false))
+	assert.Equal(t, "Tyler", current.Get("names[0].first").Data())
+	assert.Equal(t, "Bunnell", current.Get("names[0].last").Data())
+	assert.Equal(t, "Capitol", current.Get("names[1].first").Data())
+	assert.Equal(t, "Bollocks", current.Get("names[1].last").Data())
+
+	assert.Nil(t, current.Get("names[2]").Data())
 }
 
 func TestAccessorsAccessGetFromArrayWithInt(t *testing.T) {
@@ -73,35 +77,90 @@ func TestAccessorsAccessGetFromArrayWithInt(t *testing.T) {
 			"last":  "Bollocks",
 		},
 	}
-	one := access(current, 0, nil, false, false)
-	two := access(current, 1, nil, false, false)
-	three := access(current, 2, nil, false, false)
+	one := access(current, 0, nil, false)
+	two := access(current, 1, nil, false)
+	three := access(current, 2, nil, false)
 
 	assert.Equal(t, "Tyler", one.(map[string]interface{})["first"])
 	assert.Equal(t, "Capitol", two.(map[string]interface{})["first"])
 	assert.Nil(t, three)
 }
 
+func TestAccessorsAccessGetFromArrayWithIntTypes(t *testing.T) {
+	current := []interface{}{
+		"abc",
+		"def",
+	}
+	assert.Equal(t, "abc", access(current, 0, nil, false))
+	assert.Equal(t, "def", access(current, 1, nil, false))
+	assert.Nil(t, access(current, 2, nil, false))
+
+	assert.Equal(t, "abc", access(current, int8(0), nil, false))
+	assert.Equal(t, "def", access(current, int8(1), nil, false))
+	assert.Nil(t, access(current, int8(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, int16(0), nil, false))
+	assert.Equal(t, "def", access(current, int16(1), nil, false))
+	assert.Nil(t, access(current, int16(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, int32(0), nil, false))
+	assert.Equal(t, "def", access(current, int32(1), nil, false))
+	assert.Nil(t, access(current, int32(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, int64(0), nil, false))
+	assert.Equal(t, "def", access(current, int64(1), nil, false))
+	assert.Nil(t, access(current, int64(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, uint(0), nil, false))
+	assert.Equal(t, "def", access(current, uint(1), nil, false))
+	assert.Nil(t, access(current, uint(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, uint8(0), nil, false))
+	assert.Equal(t, "def", access(current, uint8(1), nil, false))
+	assert.Nil(t, access(current, uint8(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, uint16(0), nil, false))
+	assert.Equal(t, "def", access(current, uint16(1), nil, false))
+	assert.Nil(t, access(current, uint16(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, uint32(0), nil, false))
+	assert.Equal(t, "def", access(current, uint32(1), nil, false))
+	assert.Nil(t, access(current, uint32(2), nil, false))
+
+	assert.Equal(t, "abc", access(current, uint64(0), nil, false))
+	assert.Equal(t, "def", access(current, uint64(1), nil, false))
+	assert.Nil(t, access(current, uint64(2), nil, false))
+}
+
+func TestAccessorsAccessGetFromArrayWithIntError(t *testing.T) {
+	current := Map{"name": "Tyler"}
+
+	assert.Nil(t, access(current, 0, nil, false))
+}
+
 func TestAccessorsGet(t *testing.T) {
 	current := Map{"name": "Tyler"}
 
-	assert.Equal(t, "Tyler", current.Get("name").data)
+	assert.Equal(t, "Tyler", current.Get("name").Data())
 }
 
 func TestAccessorsAccessSetSingleField(t *testing.T) {
 	current := Map{"name": "Tyler"}
 
-	access(current, "name", "Mat", true, false)
-	access(current, "age", 29, true, true)
+	current.Set("name", "Mat")
+	current.Set("age", 29)
 
 	assert.Equal(t, current["name"], "Mat")
 	assert.Equal(t, current["age"], 29)
 }
 
 func TestAccessorsAccessSetSingleFieldNotExisting(t *testing.T) {
-	current := Map{}
+	current := Map{
+		"first": "Tyler",
+		"last":  "Bunnell",
+	}
 
-	access(current, "name", "Mat", true, false)
+	current.Set("name", "Mat")
 
 	assert.Equal(t, current["name"], "Mat")
 }
@@ -114,11 +173,11 @@ func TestAccessorsAccessSetDeep(t *testing.T) {
 		},
 	}
 
-	access(current, "name.first", "Mat", true, true)
-	access(current, "name.last", "Ryer", true, true)
+	current.Set("name.first", "Mat")
+	current.Set("name.last", "Ryer")
 
-	assert.Equal(t, "Mat", access(current, "name.first", nil, false, true))
-	assert.Equal(t, "Ryer", access(current, "name.last", nil, false, true))
+	assert.Equal(t, "Mat", current.Get("name.first").Data())
+	assert.Equal(t, "Ryer", current.Get("name.last").Data())
 }
 
 func TestAccessorsAccessSetDeepDeep(t *testing.T) {
@@ -131,19 +190,18 @@ func TestAccessorsAccessSetDeepDeep(t *testing.T) {
 		},
 	}
 
-	access(current, "one.two.three.four", 5, true, true)
+	current.Set("one.two.three.four", 5)
 
-	assert.Equal(t, 5, access(current, "one.two.three.four", nil, false, true))
+	assert.Equal(t, 5, current.Get("one.two.three.four").Data())
 }
 
 func TestAccessorsAccessSetArray(t *testing.T) {
 	current := Map{
 		"names": []interface{}{"Tyler"},
 	}
+	current.Set("names[0]", "Mat")
 
-	access(current, "names[0]", "Mat", true, true)
-
-	assert.Equal(t, "Mat", access(current, "names[0]", nil, false, true))
+	assert.Equal(t, "Mat", current.Get("names[0]").Data())
 }
 
 func TestAccessorsAccessSetInsideArray(t *testing.T) {
@@ -160,15 +218,15 @@ func TestAccessorsAccessSetInsideArray(t *testing.T) {
 		},
 	}
 
-	access(current, "names[0].first", "Mat", true, true)
-	access(current, "names[0].last", "Ryer", true, true)
-	access(current, "names[1].first", "Captain", true, true)
-	access(current, "names[1].last", "Underpants", true, true)
+	current.Set("names[0].first", "Mat")
+	current.Set("names[0].last", "Ryer")
+	current.Set("names[1].first", "Captain")
+	current.Set("names[1].last", "Underpants")
 
-	assert.Equal(t, "Mat", access(current, "names[0].first", nil, false, true))
-	assert.Equal(t, "Ryer", access(current, "names[0].last", nil, false, true))
-	assert.Equal(t, "Captain", access(current, "names[1].first", nil, false, true))
-	assert.Equal(t, "Underpants", access(current, "names[1].last", nil, false, true))
+	assert.Equal(t, "Mat", current.Get("names[0].first").Data())
+	assert.Equal(t, "Ryer", current.Get("names[0].last").Data())
+	assert.Equal(t, "Captain", current.Get("names[1].first").Data())
+	assert.Equal(t, "Underpants", current.Get("names[1].last").Data())
 }
 
 func TestAccessorsSet(t *testing.T) {

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -7,26 +7,50 @@ import (
 )
 
 func TestAccessorsAccessGetSingleField(t *testing.T) {
-	current := map[string]interface{}{"name": "Tyler"}
+	current := Map{"name": "Tyler"}
 
 	assert.Equal(t, "Tyler", access(current, "name", nil, false, true))
 }
 
 func TestAccessorsAccessGetDeep(t *testing.T) {
-	current := map[string]interface{}{"name": map[string]interface{}{"first": "Tyler", "last": "Bunnell"}}
+	current := Map{
+		"name": Map{
+			"first": "Tyler",
+			"last":  "Bunnell",
+		},
+	}
 
 	assert.Equal(t, "Tyler", access(current, "name.first", nil, false, true))
 	assert.Equal(t, "Bunnell", access(current, "name.last", nil, false, true))
 }
 
 func TestAccessorsAccessGetDeepDeep(t *testing.T) {
-	current := map[string]interface{}{"one": map[string]interface{}{"two": map[string]interface{}{"three": map[string]interface{}{"four": 4}}}}
+	current := Map{
+		"one": Map{
+			"two": Map{
+				"three": Map{
+					"four": 4,
+				},
+			},
+		},
+	}
 
 	assert.Equal(t, 4, access(current, "one.two.three.four", nil, false, true))
 }
 
 func TestAccessorsAccessGetInsideArray(t *testing.T) {
-	current := map[string]interface{}{"names": []interface{}{map[string]interface{}{"first": "Tyler", "last": "Bunnell"}, map[string]interface{}{"first": "Capitol", "last": "Bollocks"}}}
+	current := Map{
+		"names": []interface{}{
+			Map{
+				"first": "Tyler",
+				"last":  "Bunnell",
+			},
+			Map{
+				"first": "Capitol",
+				"last":  "Bollocks",
+			},
+		},
+	}
 
 	assert.Equal(t, "Tyler", access(current, "names[0].first", nil, false, true))
 	assert.Equal(t, "Bunnell", access(current, "names[0].last", nil, false, true))
@@ -39,7 +63,16 @@ func TestAccessorsAccessGetInsideArray(t *testing.T) {
 }
 
 func TestAccessorsAccessGetFromArrayWithInt(t *testing.T) {
-	current := []interface{}{map[string]interface{}{"first": "Tyler", "last": "Bunnell"}, map[string]interface{}{"first": "Capitol", "last": "Bollocks"}}
+	current := []interface{}{
+		map[string]interface{}{
+			"first": "Tyler",
+			"last":  "Bunnell",
+		},
+		map[string]interface{}{
+			"first": "Capitol",
+			"last":  "Bollocks",
+		},
+	}
 	one := access(current, 0, nil, false, false)
 	two := access(current, 1, nil, false, false)
 	three := access(current, 2, nil, false, false)
@@ -50,13 +83,13 @@ func TestAccessorsAccessGetFromArrayWithInt(t *testing.T) {
 }
 
 func TestAccessorsGet(t *testing.T) {
-	current := New(map[string]interface{}{"name": "Tyler"})
+	current := Map{"name": "Tyler"}
 
 	assert.Equal(t, "Tyler", current.Get("name").data)
 }
 
 func TestAccessorsAccessSetSingleField(t *testing.T) {
-	current := map[string]interface{}{"name": "Tyler"}
+	current := Map{"name": "Tyler"}
 
 	access(current, "name", "Mat", true, false)
 	access(current, "age", 29, true, true)
@@ -66,7 +99,7 @@ func TestAccessorsAccessSetSingleField(t *testing.T) {
 }
 
 func TestAccessorsAccessSetSingleFieldNotExisting(t *testing.T) {
-	current := map[string]interface{}{}
+	current := Map{}
 
 	access(current, "name", "Mat", true, false)
 
@@ -74,7 +107,12 @@ func TestAccessorsAccessSetSingleFieldNotExisting(t *testing.T) {
 }
 
 func TestAccessorsAccessSetDeep(t *testing.T) {
-	current := map[string]interface{}{"name": map[string]interface{}{"first": "Tyler", "last": "Bunnell"}}
+	current := Map{
+		"name": Map{
+			"first": "Tyler",
+			"last":  "Bunnell",
+		},
+	}
 
 	access(current, "name.first", "Mat", true, true)
 	access(current, "name.last", "Ryer", true, true)
@@ -84,7 +122,14 @@ func TestAccessorsAccessSetDeep(t *testing.T) {
 }
 
 func TestAccessorsAccessSetDeepDeep(t *testing.T) {
-	current := map[string]interface{}{"one": map[string]interface{}{"two": map[string]interface{}{"three": map[string]interface{}{"four": 4}}}}
+	current := Map{
+		"one": Map{
+			"two": Map{
+				"three": Map{
+					"four": 4},
+			},
+		},
+	}
 
 	access(current, "one.two.three.four", 5, true, true)
 
@@ -92,7 +137,9 @@ func TestAccessorsAccessSetDeepDeep(t *testing.T) {
 }
 
 func TestAccessorsAccessSetArray(t *testing.T) {
-	current := map[string]interface{}{"names": []interface{}{"Tyler"}}
+	current := Map{
+		"names": []interface{}{"Tyler"},
+	}
 
 	access(current, "names[0]", "Mat", true, true)
 
@@ -100,7 +147,18 @@ func TestAccessorsAccessSetArray(t *testing.T) {
 }
 
 func TestAccessorsAccessSetInsideArray(t *testing.T) {
-	current := map[string]interface{}{"names": []interface{}{map[string]interface{}{"first": "Tyler", "last": "Bunnell"}, map[string]interface{}{"first": "Capitol", "last": "Bollocks"}}}
+	current := Map{
+		"names": []interface{}{
+			Map{
+				"first": "Tyler",
+				"last":  "Bunnell",
+			},
+			Map{
+				"first": "Capitol",
+				"last":  "Bollocks",
+			},
+		},
+	}
 
 	access(current, "names[0].first", "Mat", true, true)
 	access(current, "names[0].last", "Ryer", true, true)
@@ -114,7 +172,7 @@ func TestAccessorsAccessSetInsideArray(t *testing.T) {
 }
 
 func TestAccessorsSet(t *testing.T) {
-	current := New(map[string]interface{}{"name": "Tyler"})
+	current := Map{"name": "Tyler"}
 
 	current.Set("name", "Mat")
 

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -1,25 +1,26 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConversionJSON(t *testing.T) {
 	jsonString := `{"name":"Mat"}`
-	o := MustFromJSON(jsonString)
+	o := objx.MustFromJSON(jsonString)
 
 	result, err := o.JSON()
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, jsonString, result)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, jsonString, result)
 	assert.Equal(t, jsonString, o.MustJSON())
 }
 
 func TestConversionJSONWithError(t *testing.T) {
-	o := MSI()
+	o := objx.MSI()
 	o["test"] = func() {}
 
 	assert.Panics(t, func() {
@@ -32,18 +33,17 @@ func TestConversionJSONWithError(t *testing.T) {
 }
 
 func TestConversionBase64(t *testing.T) {
-	o := New(map[string]interface{}{"name": "Mat"})
+	o := objx.Map{"name": "Mat"}
 
 	result, err := o.Base64()
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, "eyJuYW1lIjoiTWF0In0=", result)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "eyJuYW1lIjoiTWF0In0=", result)
 	assert.Equal(t, "eyJuYW1lIjoiTWF0In0=", o.MustBase64())
 }
 
 func TestConversionBase64WithError(t *testing.T) {
-	o := MSI()
+	o := objx.MSI()
 	o["test"] = func() {}
 
 	assert.Panics(t, func() {
@@ -56,18 +56,17 @@ func TestConversionBase64WithError(t *testing.T) {
 }
 
 func TestConversionSignedBase64(t *testing.T) {
-	o := New(map[string]interface{}{"name": "Mat"})
+	o := objx.Map{"name": "Mat"}
 
 	result, err := o.SignedBase64("key")
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, "eyJuYW1lIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6", result)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "eyJuYW1lIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6", result)
 	assert.Equal(t, "eyJuYW1lIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6", o.MustSignedBase64("key"))
 }
 
 func TestConversionSignedBase64WithError(t *testing.T) {
-	o := MSI()
+	o := objx.MSI()
 	o["test"] = func() {}
 
 	assert.Panics(t, func() {

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -1,8 +1,9 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,14 +82,14 @@ var fixtures = []struct {
 
 func TestFixtures(t *testing.T) {
 	for _, fixture := range fixtures {
-		m := MustFromJSON(fixture.data)
+		m := objx.MustFromJSON(fixture.data)
 
 		// get the value
 		t.Logf("Running get fixture: \"%s\" (%v)", fixture.name, fixture)
 		value := m.Get(fixture.get.(string))
 
 		// make sure it matches
-		assert.Equal(t, fixture.output, value.data,
+		assert.Equal(t, fixture.output, value.Data(),
 			"Get fixture \"%s\" failed: %v", fixture.name, fixture,
 		)
 	}

--- a/map.go
+++ b/map.go
@@ -47,9 +47,8 @@ func New(data interface{}) Map {
 //
 // The arguments follow a key, value pattern.
 //
-// Panics
 //
-// Panics if any key argument is non-string or if there are an odd number of arguments.
+// Returns nil if any key argument is non-string or if there are an odd number of arguments.
 //
 // Example
 //

--- a/map.go
+++ b/map.go
@@ -63,7 +63,7 @@ func MSI(keyAndValuePairs ...interface{}) Map {
 	newMap := make(map[string]interface{})
 	keyAndValuePairsLen := len(keyAndValuePairs)
 	if keyAndValuePairsLen%2 != 0 {
-		panic("objx: MSI must have an even number of arguments following the 'key, value' pattern.")
+		return nil
 	}
 
 	for i := 0; i < keyAndValuePairsLen; i = i + 2 {
@@ -73,7 +73,7 @@ func MSI(keyAndValuePairs ...interface{}) Map {
 		// make sure the key is a string
 		keyString, keyStringOK := key.(string)
 		if !keyStringOK {
-			panic("objx: MSI must follow 'string, interface{}' pattern.  " + keyString + " is not a valid key.")
+			return nil
 		}
 		newMap[keyString] = value
 	}

--- a/map.go
+++ b/map.go
@@ -58,14 +58,13 @@ func New(data interface{}) Map {
 //     m := objx.MSI("name", "Mat", "age", 29, "subobj", objx.MSI("active", true))
 //
 //     // creates an Map equivalent to
-//     m := objx.New(map[string]interface{}{"name": "Mat", "age": 29, "subobj": map[string]interface{}{"active": true}})
+//     m := objx.Map{"name": "Mat", "age": 29, "subobj": objx.Map{"active": true}}
 func MSI(keyAndValuePairs ...interface{}) Map {
-	newMap := make(map[string]interface{})
+	newMap := Map{}
 	keyAndValuePairsLen := len(keyAndValuePairs)
 	if keyAndValuePairsLen%2 != 0 {
 		return nil
 	}
-
 	for i := 0; i < keyAndValuePairsLen; i = i + 2 {
 		key := keyAndValuePairs[i]
 		value := keyAndValuePairs[i+1]
@@ -77,7 +76,7 @@ func MSI(keyAndValuePairs ...interface{}) Map {
 		}
 		newMap[keyString] = value
 	}
-	return New(newMap)
+	return newMap
 }
 
 // ****** Conversion Constructors
@@ -170,12 +169,11 @@ func FromURLQuery(query string) (Map, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	m := make(map[string]interface{})
+	m := Map{}
 	for k, vals := range vals {
 		m[k] = vals[0]
 	}
-	return New(m), nil
+	return m, nil
 }
 
 // MustFromURLQuery generates a new Obj by parsing the specified

--- a/map_test.go
+++ b/map_test.go
@@ -1,9 +1,11 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var TestMap = map[string]interface{}{
@@ -19,114 +21,152 @@ type Convertable struct {
 	name string
 }
 
-func (c *Convertable) MSI() map[string]interface{} {
-	return map[string]interface{}{"name": c.name}
-}
-
 type Unconvertable struct {
 	name string
 }
 
+func (c *Convertable) MSI() map[string]interface{} {
+	return map[string]interface{}{"name": c.name}
+}
+
 func TestMapCreation(t *testing.T) {
-	o := New(nil)
+	o := objx.New(nil)
 	assert.Nil(t, o)
 
-	o = New("Tyler")
+	o = objx.New("Tyler")
 	assert.Nil(t, o)
 
 	unconvertable := &Unconvertable{name: "Tyler"}
-	o = New(unconvertable)
+	o = objx.New(unconvertable)
 	assert.Nil(t, o)
 
 	convertable := &Convertable{name: "Tyler"}
-	o = New(convertable)
-	if assert.NotNil(t, convertable) {
-		assert.Equal(t, "Tyler", o["name"], "Tyler")
-	}
+	o = objx.New(convertable)
+	require.NotNil(t, convertable)
+	assert.Equal(t, "Tyler", o["name"], "Tyler")
 
-	o = MSI()
-	if assert.NotNil(t, o) {
-		assert.NotNil(t, o)
-	}
+	o = objx.MSI()
+	assert.NotNil(t, o)
 
-	o = MSI("name", "Tyler")
-	if assert.NotNil(t, o) {
-		if assert.NotNil(t, o) {
-			assert.Equal(t, o["name"], "Tyler")
-		}
+	o = objx.MSI("name", "Tyler")
+	require.NotNil(t, o)
+	assert.Equal(t, o["name"], "Tyler")
+
+	o = objx.MSI(1, "a")
+	assert.Nil(t, o)
+
+	o = objx.MSI("a")
+	assert.Nil(t, o)
+
+	o = objx.MSI("a", "b", "c")
+	assert.Nil(t, o)
+}
+
+func TestMapValure(t *testing.T) {
+	m := objx.Map{
+		"a": 1,
 	}
+	v := m.Value()
+
+	assert.Equal(t, m, v.ObjxMap())
 }
 
 func TestMapMustFromJSONWithError(t *testing.T) {
-	_, err := FromJSON(`"name":"Mat"}`)
+	_, err := objx.FromJSON(`"name":"Mat"}`)
 	assert.Error(t, err)
 }
 
 func TestMapFromJSON(t *testing.T) {
-	o := MustFromJSON(`{"name":"Mat"}`)
+	o := objx.MustFromJSON(`{"name":"Mat"}`)
 
-	if assert.NotNil(t, o) {
-		if assert.NotNil(t, o) {
-			assert.Equal(t, "Mat", o["name"])
-		}
-	}
+	require.NotNil(t, o)
+	assert.Equal(t, "Mat", o["name"])
 }
 
 func TestMapFromJSONWithError(t *testing.T) {
-	var m Map
+	var m objx.Map
 
 	assert.Panics(t, func() {
-		m = MustFromJSON(`"name":"Mat"}`)
+		m = objx.MustFromJSON(`"name":"Mat"}`)
 	})
 	assert.Nil(t, m)
 }
 
 func TestMapFromBase64String(t *testing.T) {
 	base64String := "eyJuYW1lIjoiTWF0In0="
-	o, err := FromBase64(base64String)
+	o, err := objx.FromBase64(base64String)
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, o.Get("name").Str(), "Mat")
-	}
-	assert.Equal(t, MustFromBase64(base64String).Get("name").Str(), "Mat")
+	require.NoError(t, err)
+	assert.Equal(t, o.Get("name").Str(), "Mat")
+	assert.Equal(t, objx.MustFromBase64(base64String).Get("name").Str(), "Mat")
 }
 
 func TestMapFromBase64StringWithError(t *testing.T) {
 	base64String := "eyJuYW1lIjoiTWFasd0In0="
-	_, err := FromBase64(base64String)
+	_, err := objx.FromBase64(base64String)
 
 	assert.Error(t, err)
 	assert.Panics(t, func() {
-		MustFromBase64(base64String)
+		objx.MustFromBase64(base64String)
 	})
 }
 
 func TestMapFromSignedBase64String(t *testing.T) {
 	base64String := "eyJuYW1lIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6"
 
-	o, err := FromSignedBase64(base64String, "key")
+	o, err := objx.FromSignedBase64(base64String, "key")
 
-	if assert.NoError(t, err) {
-		assert.Equal(t, o.Get("name").Str(), "Mat")
-	}
-	assert.Equal(t, MustFromSignedBase64(base64String, "key").Get("name").Str(), "Mat")
+	require.NoError(t, err)
+	assert.Equal(t, o.Get("name").Str(), "Mat")
+	assert.Equal(t, objx.MustFromSignedBase64(base64String, "key").Get("name").Str(), "Mat")
 }
 
 func TestMapFromSignedBase64StringWithError(t *testing.T) {
 	base64String := "eyJuYW1lasdIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6"
-	_, err := FromSignedBase64(base64String, "key")
-
+	_, err := objx.FromSignedBase64(base64String, "key")
 	assert.Error(t, err)
 	assert.Panics(t, func() {
-		MustFromSignedBase64(base64String, "key")
+		objx.MustFromSignedBase64(base64String, "key")
+	})
+
+	base64String = "eyJuYW1lasdIjoiTWF0In0=67ee82916f90b2c0d68c903266e8998c9ef0c3d6"
+	_, err = objx.FromSignedBase64(base64String, "key")
+	assert.Error(t, err)
+	assert.Panics(t, func() {
+		objx.MustFromSignedBase64(base64String, "key")
+	})
+
+	base64String = "eyJuYW1lIjoiTWF0In0=_67ee82916f90b2c0d68c903266e8998c9ef0c3d6_junk"
+	_, err = objx.FromSignedBase64(base64String, "key")
+	assert.Error(t, err)
+	assert.Panics(t, func() {
+		objx.MustFromSignedBase64(base64String, "key")
 	})
 }
 
 func TestMapFromURLQuery(t *testing.T) {
-	m, err := FromURLQuery("name=tyler&state=UT")
+	m, err := objx.FromURLQuery("name=tyler&state=UT")
 
-	if assert.NoError(t, err) && assert.NotNil(t, m) {
-		assert.Equal(t, "tyler", m.Get("name").Str())
-		assert.Equal(t, "UT", m.Get("state").Str())
-	}
+	assert.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "tyler", m.Get("name").Str())
+	assert.Equal(t, "UT", m.Get("state").Str())
+}
+
+func TestMapMustFromURLQuery(t *testing.T) {
+	m := objx.MustFromURLQuery("name=tyler&state=UT")
+
+	require.NotNil(t, m)
+	assert.Equal(t, "tyler", m.Get("name").Str())
+	assert.Equal(t, "UT", m.Get("state").Str())
+}
+
+func TestMapFromURLQueryWithError(t *testing.T) {
+	m, err := objx.FromURLQuery("%")
+
+	assert.Error(t, err)
+	assert.Nil(t, m)
+	assert.Panics(t, func() {
+		objx.MustFromURLQuery("%")
+	})
 }

--- a/map_test.go
+++ b/map_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var TestMap = map[string]interface{}{
+var TestMap = objx.Map{
 	"name": "Tyler",
-	"address": map[string]interface{}{
+	"address": objx.Map{
 		"city":  "Salt Lake City",
 		"state": "UT",
 	},
@@ -26,7 +26,7 @@ type Unconvertable struct {
 }
 
 func (c *Convertable) MSI() map[string]interface{} {
-	return map[string]interface{}{"name": c.name}
+	return objx.Map{"name": c.name}
 }
 
 func TestMapCreation(t *testing.T) {
@@ -43,7 +43,7 @@ func TestMapCreation(t *testing.T) {
 	convertable := &Convertable{name: "Tyler"}
 	o = objx.New(convertable)
 	require.NotNil(t, convertable)
-	assert.Equal(t, "Tyler", o["name"], "Tyler")
+	assert.Equal(t, "Tyler", o["name"])
 
 	o = objx.MSI()
 	assert.NotNil(t, o)

--- a/mutations.go
+++ b/mutations.go
@@ -14,11 +14,11 @@ func (m Map) Exclude(exclude []string) Map {
 
 // Copy creates a shallow copy of the Obj.
 func (m Map) Copy() Map {
-	copied := make(map[string]interface{})
+	copied := Map{}
 	for k, v := range m {
 		copied[k] = v
 	}
-	return New(copied)
+	return copied
 }
 
 // Merge blends the specified map with a copy of this map and returns the result.
@@ -45,12 +45,12 @@ func (m Map) MergeHere(merge Map) Map {
 // to change the keys and values as it goes. This method requires that
 // the wrapped object be a map[string]interface{}
 func (m Map) Transform(transformer func(key string, value interface{}) (string, interface{})) Map {
-	newMap := make(map[string]interface{})
+	newMap := Map{}
 	for k, v := range m {
 		modifiedKey, modifiedVal := transformer(k, v)
 		newMap[modifiedKey] = modifiedVal
 	}
-	return New(newMap)
+	return newMap
 }
 
 // TransformKeys builds a new map using the specified key mapping.

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExclude(t *testing.T) {
@@ -29,6 +30,7 @@ func TestCopy(t *testing.T) {
 	}
 
 	m2 := m1.Copy()
+	require.NotNil(t, m2)
 	m2["name"] = "Mat"
 
 	assert.Equal(t, m1.Get("name").Str(), "Tyler")

--- a/security.go
+++ b/security.go
@@ -5,13 +5,8 @@ import (
 	"encoding/hex"
 )
 
-// HashWithKey hashes the specified string using the security
-// key.
+// HashWithKey hashes the specified string using the security key
 func HashWithKey(data, key string) string {
-	hash := sha1.New()
-	_, err := hash.Write([]byte(data + ":" + key))
-	if err != nil {
-		return ""
-	}
-	return hex.EncodeToString(hash.Sum(nil))
+	d := sha1.Sum([]byte(data + ":" + key))
+	return hex.EncodeToString(d[:])
 }

--- a/security_test.go
+++ b/security_test.go
@@ -1,11 +1,12 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHashWithKey(t *testing.T) {
-	assert.Equal(t, "0ce84d8d01f2c7b6e0882b784429c54d280ea2d9", HashWithKey("abc", "def"))
+	assert.Equal(t, "0ce84d8d01f2c7b6e0882b784429c54d280ea2d9", objx.HashWithKey("abc", "def"))
 }

--- a/simple_example_test.go
+++ b/simple_example_test.go
@@ -1,21 +1,23 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleExample(t *testing.T) {
 	// build a map from a JSON object
-	o := MustFromJSON(`{"name":"Mat","foods":["indian","chinese"], "location":{"county":"hobbiton","city":"the shire"}}`)
+	o := objx.MustFromJSON(`{"name":"Mat","foods":["indian","chinese"], "location":{"county":"hobbiton","city":"the shire"}}`)
 
 	// Map can be used as a straight map[string]interface{}
 	assert.Equal(t, o["name"], "Mat")
 
 	// Get an Value object
 	v := o.Get("name")
-	assert.Equal(t, v, &Value{data: "Mat"})
+	require.NotNil(t, v)
 
 	// Test the contained value
 	assert.False(t, v.IsInt())

--- a/tests_test.go
+++ b/tests_test.go
@@ -1,13 +1,14 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHas(t *testing.T) {
-	m := New(TestMap)
+	m := objx.Map(TestMap)
 
 	assert.True(t, m.Has("name"))
 	assert.True(t, m.Has("address.state"))

--- a/value.go
+++ b/value.go
@@ -49,6 +49,5 @@ func (v *Value) String() string {
 	case v.IsUint64():
 		return strconv.FormatUint(v.Uint64(), 10)
 	}
-
 	return fmt.Sprintf("%#v", v.Data())
 }

--- a/value.go
+++ b/value.go
@@ -30,8 +30,6 @@ func (v *Value) String() string {
 		return strconv.FormatFloat(v.Float64(), 'f', -1, 64)
 	case v.IsInt():
 		return strconv.FormatInt(int64(v.Int()), 10)
-	case v.IsInt():
-		return strconv.FormatInt(int64(v.Int()), 10)
 	case v.IsInt8():
 		return strconv.FormatInt(int64(v.Int8()), 10)
 	case v.IsInt16():

--- a/value_test.go
+++ b/value_test.go
@@ -1,31 +1,36 @@
-package objx
+package objx_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStringTypeString(t *testing.T) {
-	m := New(map[string]interface{}{"string": "foo"})
+	m := objx.Map{
+		"string": "foo",
+	}
 
 	assert.Equal(t, "foo", m.Get("string").String())
 }
 
 func TestStringTypeBool(t *testing.T) {
-	m := New(map[string]interface{}{"bool": true})
+	m := objx.Map{
+		"bool": true,
+	}
 
 	assert.Equal(t, "true", m.Get("bool").String())
 }
 
 func TestStringTypeInt(t *testing.T) {
-	m := New(map[string]interface{}{
+	m := objx.Map{
 		"int":   int(1),
 		"int8":  int8(8),
 		"int16": int16(16),
 		"int32": int32(32),
 		"int64": int64(64),
-	})
+	}
 
 	assert.Equal(t, "1", m.Get("int").String())
 	assert.Equal(t, "8", m.Get("int8").String())
@@ -35,13 +40,13 @@ func TestStringTypeInt(t *testing.T) {
 }
 
 func TestStringTypeUint(t *testing.T) {
-	m := New(map[string]interface{}{
+	m := objx.Map{
 		"uint":   uint(1),
 		"uint8":  uint8(8),
 		"uint16": uint16(16),
 		"uint32": uint32(32),
 		"uint64": uint64(64),
-	})
+	}
 
 	assert.Equal(t, "1", m.Get("uint").String())
 	assert.Equal(t, "8", m.Get("uint8").String())
@@ -51,19 +56,19 @@ func TestStringTypeUint(t *testing.T) {
 }
 
 func TestStringTypeFloat(t *testing.T) {
-	m := New(map[string]interface{}{
+	m := objx.Map{
 		"float32": float32(32.32),
 		"float64": float64(64.64),
-	})
+	}
 
 	assert.Equal(t, "32.32", m.Get("float32").String())
 	assert.Equal(t, "64.64", m.Get("float64").String())
 }
 
 func TestStringTypeOther(t *testing.T) {
-	m := New(map[string]interface{}{
+	m := objx.Map{
 		"other": []string{"foo", "bar"},
-	})
+	}
 
 	assert.Equal(t, "[]string{\"foo\", \"bar\"}", m.Get("other").String())
 }

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,28 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//    import (
+//      "testing"
+//      "github.com/stretchr/testify/require"
+//    )
+//
+//    func TestSomething(t *testing.T) {
+//
+//      var a string = "Hello"
+//      var b string = "Hello"
+//
+//      require.Equal(t, a, b, "The two words should be the same.")
+//
+//    }
+//
+// Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require_forward.go.tmpl -include-format-funcs

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,979 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if !assert.Conditionf(t, comp, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Contains(t, "Hello World", "World")
+//    assert.Contains(t, ["Hello", "World"], "World")
+//    assert.Contains(t, {"Hello": "World"}, "Hello")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if !assert.Containsf(t, s, contains, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if !assert.DirExists(t, path, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if !assert.DirExistsf(t, path, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2]))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if !assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if !assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Empty(t, obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Emptyf(t, obj, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.Emptyf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Equal asserts that two objects are equal.
+//
+//    assert.Equal(t, 123, 123)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualError(t, err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if !assert.EqualErrorf(t, theError, errString, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValues(t, uint32(123), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValuesf(t, uint32(123, "error message %s", "formatted"), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.EqualValuesf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.Equalf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Error(t, err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Errorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if !assert.Errorf(t, err, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    assert.Exactly(t, int32(123), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.Exactlyf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.Fail(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if !assert.FailNowf(t, failureMessage, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if !assert.Failf(t, failureMessage, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// False asserts that the specified value is false.
+//
+//    assert.False(t, myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    assert.Falsef(t, myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if !assert.Falsef(t, value, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if !assert.FileExists(t, path, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if !assert.FileExistsf(t, path, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContainsf(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if !assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContainsf(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if !assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if !assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if !assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if !assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDeltaf(t, math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if !assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if !assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if !assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if !assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if !assert.IsTypef(t, expectedType, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if !assert.JSONEqf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    assert.Len(t, mySlice, 3)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if !assert.Lenf(t, object, length, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    assert.Nil(t, err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    assert.Nilf(t, err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.Nilf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoError(t, err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoErrorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if !assert.NoErrorf(t, err, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContains(t, "Hello World", "Earth")
+//    assert.NotContains(t, ["Hello", "World"], "Earth")
+//    assert.NotContains(t, {"Hello": "World"}, "Earth")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if !assert.NotContainsf(t, s, contains, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmpty(t, obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.NotEmptyf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    assert.NotEqual(t, obj1, obj2)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if !assert.NotEqualf(t, expected, actual, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    assert.NotNil(t, err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    assert.NotNilf(t, err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if !assert.NotNilf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanics(t, func(){ RemainCalm() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.NotPanicsf(t, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  assert.NotRegexp(t, "^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexpf(t, regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
+//  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if !assert.NotRegexpf(t, rx, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotSubset(t, list, subset, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if !assert.NotSubsetf(t, list, subset, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotZero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotZerof asserts that i is not the zero value for its type and returns the truth.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if !assert.NotZerof(t, i, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if !assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if !assert.Panicsf(t, f, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  assert.Regexp(t, "start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  assert.Regexpf(t, regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
+//  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if !assert.Regexpf(t, rx, str, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if !assert.Subset(t, list, subset, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if !assert.Subsetf(t, list, subset, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// True asserts that the specified value is true.
+//
+//    assert.True(t, myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Truef asserts that the specified value is true.
+//
+//    assert.Truef(t, myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if !assert.Truef(t, value, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if !assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		t.FailNow()
+	}
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if !assert.Zero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Zerof asserts that i is the zero value for its type and returns the truth.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if !assert.Zerof(t, i, msg, args...) {
+		t.FailNow()
+	}
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,799 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Contains("Hello World", "World")
+//    a.Contains(["Hello", "World"], "World")
+//    a.Contains({"Hello": "World"}, "Hello")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Containsf("Hello World", "World", "error message %s", "formatted")
+//    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2]))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Empty(obj)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Emptyf(obj, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    a.Equal(123, 123)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualError(err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValues(uint32(123), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValuesf(uint32(123, "error message %s", "formatted"), int32(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Error(err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	Error(a.t, err, msgAndArgs...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Errorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	Errorf(a.t, err, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    a.Exactly(int32(123), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    a.Exactlyf(int32(123, "error message %s", "formatted"), int64(123))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//    a.False(myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    a.Falsef(myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContainsf(myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContainsf(myHandler, "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    a.Implementsf((*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDeltaf(math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    a.Len(mySlice, 3)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    a.Lenf(mySlice, 3, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    a.Nil(err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    a.Nilf(err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoError(err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoErrorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContains("Hello World", "Earth")
+//    a.NotContains(["Hello", "World"], "Earth")
+//    a.NotContains({"Hello": "World"}, "Earth")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmpty(obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmptyf(obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    a.NotEqual(obj1, obj2)
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    a.NotNil(err)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    a.NotNilf(err, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanics(func(){ RemainCalm() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//  a.NotRegexp("^start", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexpf(regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
+//  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type and returns the truth.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type and returns the truth.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panics(func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  a.Regexp(regexp.MustCompile("start"), "it's starting")
+//  a.Regexp("start...$", "it's not starting")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  a.Regexpf(regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
+//  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//    a.True(myBool)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//    a.Truef(myBool, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type and returns the truth.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type and returns the truth.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,9 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+//go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs


### PR DESCRIPTION
### What does this PR do
- Moves most of the test to `objx_test` package
- Makes code more compact
- Adds tests
- Ignores `doc.go` for codeclimate
- Add `github.com/stretchr/testify/require` to `vendor`
- `func MSI(keyAndValuePairs ...interface{}) Map` does not longer panik, when called with wrong arguments

### TODO
- [x] Add documenation for ` func MSI(keyAndValuePairs ...interface{}) Map `
