### PR TITLE
URLValues without sprintf with support for maps and slices

### DIFF
--- a/conversions_test.go
+++ b/conversions_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/objx"
+	"github.com/earncef/objx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,17 +80,68 @@ func TestConversionSignedBase64WithError(t *testing.T) {
 }
 
 func TestConversionURLValues(t *testing.T) {
-	m := objx.Map{"abc": 123, "name": "Mat"}
+	m := objx.Map{
+		"abc": 123,
+		"name": "Mat",
+		"data": objx.Map {"age": 30, "height": 162, "arr": []int {1, 2}},
+		"mapSlice": []objx.Map {objx.Map{"age": 40}, objx.Map{"height": 152}},
+		"stats": []string {"1", "2"},
+		"bools": []bool {true, false},
+	}
 	u := m.URLValues()
 
-	assert.Equal(t, url.Values{"abc": []string{"123"}, "name": []string{"Mat"}}, u)
+	assert.Equal(t, url.Values{
+		"abc": []string{"123"},
+		"name": []string{"Mat"},
+		"data[age]": []string{"30"},
+		"data[height]": []string{"162"},
+		"data[arr][]": []string{"1", "2"},
+		"stats[]": []string{"1", "2"},
+		"bools[]": []string{"true", "false"},
+		"mapSlice[][age]": []string{"40"},
+		"mapSlice[][height]": []string{"152"},
+	}, u)
 }
 
 func TestConversionURLQuery(t *testing.T) {
-	m := objx.Map{"abc": 123, "name": "Mat"}
+	m := objx.Map{
+		"abc": 123,
+		"name": "Mat",
+		"data": objx.Map {"age": 30, "height": 162, "arr": []int {1, 2}},
+		"mapSlice": []objx.Map {objx.Map{"age": 40}, objx.Map{"height": 152}},
+		"stats": []string {"1", "2"},
+		"bools": []bool {true, false},
+	}
 	u, err := m.URLQuery()
 
 	assert.Nil(t, err)
 	require.NotNil(t, u)
-	assert.Equal(t, "abc=123&name=Mat", u)
+
+	ue, err := url.QueryUnescape(u)
+	assert.Nil(t, err)
+	require.NotNil(t, ue)
+
+	assert.Equal(t, "abc=123&bools[]=true&bools[]=false&data[age]=30&data[arr][]=1&data[arr][]=2&data[height]=162&mapSlice[][age]=40&mapSlice[][height]=152&name=Mat&stats[]=1&stats[]=2", ue)
+}
+
+func TestConversionURLQueryNoSliceKeySuffix(t *testing.T) {
+	m := objx.Map{
+		"abc": 123,
+		"name": "Mat",
+		"data": objx.Map {"age": 30, "height": 162, "arr": []int {1, 2}},
+		"mapSlice": []objx.Map {objx.Map{"age": 40}, objx.Map{"height": 152}},
+		"stats": []string {"1", "2"},
+		"bools": []bool {true, false},
+	}
+	objx.QuerySliceKeySuffix = ""
+	u, err := m.URLQuery()
+
+	assert.Nil(t, err)
+	require.NotNil(t, u)
+
+	ue, err := url.QueryUnescape(u)
+	assert.Nil(t, err)
+	require.NotNil(t, ue)
+
+	assert.Equal(t, "abc=123&bools=true&bools=false&data[age]=30&data[arr]=1&data[arr]=2&data[height]=162&mapSlice[age]=40&mapSlice[height]=152&name=Mat&stats=1&stats=2", ue)
 }

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/earncef/objx"
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/value.go
+++ b/value.go
@@ -51,3 +51,107 @@ func (v *Value) String() string {
 	}
 	return fmt.Sprintf("%#v", v.Data())
 }
+
+// String returns the value always as a string
+func (v *Value) StringSlice(optionalDefault ...[]string) []string {
+	switch {
+	case v.IsStrSlice():
+		return v.MustStrSlice()
+	case v.IsBoolSlice():
+		slice := v.MustBoolSlice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatBool(iv)
+		}
+		return vals
+	case v.IsFloat32Slice():
+		slice := v.MustFloat32Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatFloat(float64(iv), 'f', -1, 32)
+		}
+		return vals
+    case v.IsFloat64Slice():
+        slice := v.MustFloat64Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatFloat(iv, 'f', -1, 64)
+        }
+		return vals
+    case v.IsIntSlice():
+        slice := v.MustIntSlice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatInt(int64(iv), 10)
+        }
+		return vals
+    case v.IsInt8Slice():
+        slice := v.MustInt8Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatInt(int64(iv), 10)
+        }
+		return vals
+    case v.IsInt16Slice():
+        slice := v.MustInt16Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatInt(int64(iv), 10)
+        }
+		return vals
+    case v.IsInt32Slice():
+        slice := v.MustInt32Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatInt(int64(iv), 10)
+        }
+		return vals
+    case v.IsInt64Slice():
+        slice := v.MustInt64Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatInt(iv, 10)
+        }
+		return vals
+    case v.IsUintSlice():
+        slice := v.MustUintSlice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatUint(uint64(iv), 10)
+        }
+		return vals
+    case v.IsUint8Slice():
+        slice := v.MustUint8Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatUint(uint64(iv), 10)
+        }
+		return vals
+    case v.IsUint16Slice():
+        slice := v.MustUint16Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatUint(uint64(iv), 10)
+        }
+        return vals
+    case v.IsUint32Slice():
+        slice := v.MustUint32Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatUint(uint64(iv), 10)
+        }
+        return vals
+    case v.IsUint64Slice():
+        slice := v.MustUint64Slice()
+        vals := make([]string, len(slice))
+        for i, iv := range slice {
+            vals[i] = strconv.FormatUint(iv, 10)
+        }
+		return vals
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+
+	return []string{}
+}

--- a/value_test.go
+++ b/value_test.go
@@ -3,7 +3,7 @@ package objx_test
 import (
 	"testing"
 
-	"github.com/stretchr/objx"
+	"github.com/earncef/objx"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,3 +72,71 @@ func TestStringTypeOther(t *testing.T) {
 
 	assert.Equal(t, "[]string{\"foo\", \"bar\"}", m.Get("other").String())
 }
+
+func TestStringSliceTypeString(t *testing.T) {
+	m := objx.Map{
+		"string": []string {"foo", "bar"},
+	}
+
+	assert.Equal(t, []string {"foo", "bar"}, m.Get("string").StringSlice())
+}
+
+func TestStringSliceTypeBool(t *testing.T) {
+	m := objx.Map{
+		"bool": []bool {true, false},
+	}
+
+	assert.Equal(t, []string{"true", "false"}, m.Get("bool").StringSlice())
+}
+
+func TestStringSliceTypeInt(t *testing.T) {
+	m := objx.Map{
+        "int":   []int{1, 2},
+        "int8":  []int8{8, 9},
+        "int16": []int16{16, 17},
+        "int32": []int32{32, 33},
+        "int64": []int64{64, 65},
+	}
+
+	assert.Equal(t, []string {"1", "2"}, m.Get("int").StringSlice())
+	assert.Equal(t, []string {"8", "9"}, m.Get("int8").StringSlice())
+	assert.Equal(t, []string {"16", "17"}, m.Get("int16").StringSlice())
+	assert.Equal(t, []string {"32", "33"}, m.Get("int32").StringSlice())
+	assert.Equal(t, []string {"64", "65"}, m.Get("int64").StringSlice())
+}
+
+func TestStringSliceTypeUint(t *testing.T) {
+	m := objx.Map {
+		"uint":   []uint{1, 2},
+		"uint8":  []uint8{8, 9},
+		"uint16": []uint16{16, 17},
+		"uint32": []uint32{32, 33},
+		"uint64": []uint64{64, 65},
+	}
+
+	assert.Equal(t, []string {"1", "2"}, m.Get("uint").StringSlice())
+	assert.Equal(t, []string {"8", "9"}, m.Get("uint8").StringSlice())
+	assert.Equal(t, []string {"16", "17"}, m.Get("uint16").StringSlice())
+	assert.Equal(t, []string {"32", "33"}, m.Get("uint32").StringSlice())
+	assert.Equal(t, []string {"64", "65"}, m.Get("uint64").StringSlice())
+}
+
+func TestStringSliceTypeFloat(t *testing.T) {
+	m := objx.Map{
+		"float32": []float32{32.32, 33.33},
+		"float64": []float64{64.64, 65.65},
+	}
+
+	assert.Equal(t, []string {"32.32", "33.33"}, m.Get("float32").StringSlice())
+	assert.Equal(t, []string {"64.64", "65.65"}, m.Get("float64").StringSlice())
+}
+
+func TestStringSliceTypeOther(t *testing.T) {
+	m := objx.Map{
+		"other": "foo",
+	}
+
+	assert.Equal(t, []string{}, m.Get("other").StringSlice())
+	assert.Equal(t, []string{"bar"}, m.Get("other").StringSlice([]string{"bar"}))
+}
+

--- a/value_test.go
+++ b/value_test.go
@@ -3,7 +3,7 @@ package objx_test
 import (
 	"testing"
 
-	"github.com/earncef/objx"
+	"github.com/stretchr/objx"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Slices can be configured to have a specified suffix. For ex:
a[]=b&a[]=c if the suffix is "[]"
a=b&a=c if the suffix is ""
