### PR TITLE
FEATURE: Set() with key pointing to nonexistent map path

### DIFF
--- a/accessors.go
+++ b/accessors.go
@@ -92,6 +92,12 @@ func access(current interface{}, selector string, value interface{}, isSet bool)
 			curMSI[thisSel] = value
 			return nil
 		}
+
+		_, ok := curMSI[thisSel].(map[string]interface{})
+		if (curMSI[thisSel] == nil || !ok) && index == -1 && isSet {
+			curMSI[thisSel] = map[string]interface{}{}
+		}
+
 		current = curMSI[thisSel]
 	default:
 		current = nil

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -131,6 +131,23 @@ func TestAccessorsAccessSetDeepDeep(t *testing.T) {
 	assert.Equal(t, 5, m.Get("one.two.three.four").Data())
 }
 
+func TestAccessorsAccessSetDeepDeepWithoutExisting(t *testing.T) {
+	m := objx.Map{}
+
+	m.Set("one.two.three.four", 5)
+	m.Set("one.two.three.five", 6)
+
+	assert.Equal(t, 5, m.Get("one.two.three.four").Data())
+	assert.Equal(t, 6, m.Get("one.two.three.five").Data())
+
+	m.Set("one.two", 7)
+	assert.Equal(t, 7, m.Get("one.two").Data())
+	assert.Equal(t, nil, m.Get("one.two.three.four").Data())
+
+	m.Set("one.two.three", 8)
+	assert.Equal(t, 8, m.Get("one.two.three").Data())
+}
+
 func TestAccessorsAccessSetArray(t *testing.T) {
 	m := objx.Map{
 		"names": []interface{}{"Tyler"},


### PR DESCRIPTION
When calling Set() on a nonexistent map path, the path can be created quite easily in case of MSIs. 

I have not written an implementation for arrays, as that might be problematic in case of keys like obj.Set("a.b[10000].c", ...)