### PR TITLE
New tests for type_specific.go and fixed code

### DIFF
--- a/conversions_test.go
+++ b/conversions_test.go
@@ -130,7 +130,7 @@ func getURLQueryMap() objx.Map {
 		"abc":      123,
 		"name":     "Mat",
 		"data":     objx.Map{"age": 30, "height": 162, "arr": []int{1, 2}},
-		"mapSlice": []objx.Map{objx.Map{"age": 40}, objx.Map{"height": 152}},
+		"mapSlice": []objx.Map{{"age": 40}, {"height": 152}},
 		"stats":    []string{"1", "2"},
 		"bools":    []bool{true, false},
 	}

--- a/type_specific.go
+++ b/type_specific.go
@@ -36,8 +36,8 @@ func (v *Value) MSISlice(optionalDefault ...[]map[string]interface{}) []map[stri
 		return s
 	}
 
-	s, ok := v.data.([]Map)
-	if !ok {
+	s := v.ObjxMapSlice()
+	if s == nil {
 		if len(optionalDefault) == 1 {
 			return optionalDefault[0]
 		}
@@ -55,16 +55,11 @@ func (v *Value) MSISlice(optionalDefault ...[]map[string]interface{}) []map[stri
 //
 // Panics if the object is not a []map[string]interface{}.
 func (v *Value) MustMSISlice() []map[string]interface{} {
-	s, ok := v.data.([]Map)
-	if !ok {
-		return v.data.([]map[string]interface{})
+	if s := v.MSISlice(); s != nil {
+		return s
 	}
 
-	result := make([]map[string]interface{}, len(s))
-	for i := range s {
-		result[i] = s[i].Value().MustMSI()
-	}
-	return result
+	return v.data.([]map[string]interface{})
 }
 
 // IsMSI gets whether the object contained is a map[string]interface{} or not.
@@ -213,6 +208,8 @@ func (v *Value) ObjxMapSlice(optionalDefault ...[](Map)) [](Map) {
 		switch s[i].(type) {
 		case Map:
 			result[i] = s[i].(Map)
+		case map[string]interface{}:
+			result[i] = New(s[i])
 		default:
 			return nil
 		}
@@ -224,12 +221,8 @@ func (v *Value) ObjxMapSlice(optionalDefault ...[](Map)) [](Map) {
 //
 // Panics if the object is not a [](Map).
 func (v *Value) MustObjxMapSlice() [](Map) {
-	if s, ok := v.data.([]map[string]interface{}); ok {
-		result := make([]Map, len(s))
-		for i := range s {
-			result[i] = s[i]
-		}
-		return result
+	if s := v.ObjxMapSlice(); s != nil {
+		return s
 	}
 	return v.data.([](Map))
 }

--- a/type_specific_test.go
+++ b/type_specific_test.go
@@ -29,12 +29,19 @@ func TestMSI(t *testing.T) {
 
 func TestMSISlice(t *testing.T) {
 	val := map[string]interface{}(map[string]interface{}{"name": "Tyler"})
-	m := objx.Map{"value": []map[string]interface{}{val}, "value2": []objx.Map{val}, "nothing": nil}
+	m := objx.Map{
+		"value":   []map[string]interface{}{val},
+		"value2":  []objx.Map{val},
+		"value3":  []interface{}{val},
+		"nothing": nil,
+	}
 
 	assert.Equal(t, val, m.Get("value").MSISlice()[0])
 	assert.Equal(t, val, m.Get("value2").MSISlice()[0])
+	assert.Equal(t, val, m.Get("value3").MSISlice()[0])
 	assert.Equal(t, val, m.Get("value").MustMSISlice()[0])
 	assert.Equal(t, val, m.Get("value2").MustMSISlice()[0])
+	assert.Equal(t, val, m.Get("value3").MustMSISlice()[0])
 	assert.Equal(t, []map[string]interface{}(nil), m.Get("nothing").MSISlice())
 	assert.Equal(t, val, m.Get("nothing").MSISlice([]map[string]interface{}{map[string]interface{}(map[string]interface{}{"name": "Tyler"})})[0])
 	assert.Panics(t, func() {
@@ -230,13 +237,23 @@ func TestObjxMap(t *testing.T) {
 
 func TestObjxMapSlice(t *testing.T) {
 	val := (objx.Map)(objx.New(1))
-	m := objx.Map{"value": [](objx.Map){val}, "value2": []map[string]interface{}{map[string]interface{}(map[string]interface{}{"name": "Taylor"})}, "nothing": nil}
+	m := objx.Map{
+		"value":   [](objx.Map){val},
+		"value2":  []map[string]interface{}{map[string]interface{}(map[string]interface{}{"name": "Taylor"})},
+		"value3":  []interface{}{val},
+		"value4":  []interface{}{map[string]interface{}(map[string]interface{}{"name": "Taylor"})},
+		"nothing": nil,
+	}
 	valMSI := objx.Map{"name": "Taylor"}
 
 	assert.Equal(t, val, m.Get("value").ObjxMapSlice()[0])
 	assert.Equal(t, valMSI, m.Get("value2").ObjxMapSlice()[0])
+	assert.Equal(t, val, m.Get("value3").ObjxMapSlice()[0])
+	assert.Equal(t, valMSI, m.Get("value4").ObjxMapSlice()[0])
 	assert.Equal(t, val, m.Get("value").MustObjxMapSlice()[0])
 	assert.Equal(t, valMSI, m.Get("value2").MustObjxMapSlice()[0])
+	assert.Equal(t, val, m.Get("value3").MustObjxMapSlice()[0])
+	assert.Equal(t, valMSI, m.Get("value4").MustObjxMapSlice()[0])
 	assert.Equal(t, [](objx.Map)(nil), m.Get("nothing").ObjxMapSlice())
 	assert.Equal(t, val, m.Get("nothing").ObjxMapSlice([](objx.Map){(objx.Map)(objx.New(1))})[0])
 	assert.Panics(t, func() {

--- a/type_specific_test.go
+++ b/type_specific_test.go
@@ -76,7 +76,7 @@ func TestEachMSI(t *testing.T) {
 		return i != 2
 	}))
 
-	m2 := objx.Map{"data": []objx.Map{objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}}}
+	m2 := objx.Map{"data": []objx.Map{{"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}}}
 	assert.Equal(t, m2.Get("data"), m2.Get("data").EachMSI(func(i int, val map[string]interface{}) bool {
 		count++
 		replacedVals = append(replacedVals, val)
@@ -105,7 +105,7 @@ func TestWhereMSI(t *testing.T) {
 }
 
 func TestWhereMSI2(t *testing.T) {
-	m := objx.Map{"data": []objx.Map{objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}}}
+	m := objx.Map{"data": []objx.Map{{"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}}}
 
 	selected := m.Get("data").WhereMSI(func(i int, val map[string]interface{}) bool {
 		return i%2 == 0
@@ -127,7 +127,7 @@ func TestGroupMSI(t *testing.T) {
 }
 
 func TestGroupMSI2(t *testing.T) {
-	m := objx.Map{"data": []objx.Map{objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}}}
+	m := objx.Map{"data": []objx.Map{{"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}}}
 
 	grouped := m.Get("data").GroupMSI(func(i int, val map[string]interface{}) string {
 		return fmt.Sprintf("%v", i%2 == 0)
@@ -161,7 +161,7 @@ func TestReplaceMSI(t *testing.T) {
 }
 
 func TestReplaceMSI2(t *testing.T) {
-	m := objx.Map{"data": []objx.Map{objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}}}
+	m := objx.Map{"data": []objx.Map{{"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}}}
 	rawArr := m.Get("data").MustMSISlice()
 
 	replaced := m.Get("data").ReplaceMSI(func(index int, val map[string]interface{}) map[string]interface{} {
@@ -200,7 +200,7 @@ func TestCollectMSI(t *testing.T) {
 }
 
 func TestCollectMSI2(t *testing.T) {
-	m := objx.Map{"data": []objx.Map{objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}, objx.Map{"name": "Taylor"}}}
+	m := objx.Map{"data": []objx.Map{{"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}, {"name": "Taylor"}}}
 
 	collected := m.Get("data").CollectMSI(func(index int, val map[string]interface{}) interface{} {
 		return index


### PR DESCRIPTION
There was some code in type_specific.go:ObjxMapSlice() (migrated from the original type_specific_codegen.go) which seemed to be for the purpose of converting []interface{Map...} to []Map, but contained no tests and didn't work for []MSI or []interface{MSI...}

Fixed, and added tests.