### PR TITLE
Update to go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 go:
-  - "1.7.x"
-  - "1.8.x"
   - "1.9.x"
   - "1.10.x"
+  - "1.11.x"
   - master
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To update Objx to the latest version, run:
     go get -u github.com/stretchr/objx
 
 ### Supported go versions
-We support the lastest three major Go versions, which are 1.8, 1.9 and 1.10 at the moment.
+We support the lastest three major Go versions, which are 1.9, 1.10 and 1.11 at the moment.
 
 ## Contributing
 Please feel free to submit issues, fork the repository and send pull requests!


### PR DESCRIPTION
#### Summary
This PR uses go 1.11 for testing. It also update the readme.

#### Checklist
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
