### PR TITLE
Fix for map[interface{}]interface{} to JSON conversion

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -47,11 +48,74 @@ func SetURLValuesSliceKeySuffix(s string) error {
 // JSON converts the contained object to a JSON string
 // representation
 func (m Map) JSON() (string, error) {
+	for k, v := range m {
+		m[k] = cleanUp(v)
+	}
+
 	result, err := json.Marshal(m)
 	if err != nil {
 		err = errors.New("objx: JSON encode failed with: " + err.Error())
 	}
 	return string(result), err
+}
+
+func cleanUpInterfaceArray(in []interface{}) []interface{} {
+	result := make([]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUp(v)
+	}
+	return result
+}
+
+func cleanUpInterfaceMap(in map[interface{}]interface{}) Map {
+	result := Map{}
+	for k, v := range in {
+		result[fmt.Sprintf("%v", k)] = cleanUp(v)
+	}
+	fmt.Println(result)
+	return result
+}
+
+func cleanUpStringMap(in map[string]interface{}) Map {
+	result := Map{}
+	for k, v := range in {
+		result[k] = cleanUp(v)
+	}
+	fmt.Println(result)
+	return result
+}
+
+func cleanUpMSIArray(in []map[string]interface{}) []Map {
+	result := make([]Map, len(in))
+	for i, v := range in {
+		result[i] = cleanUpStringMap(v)
+	}
+	return result
+}
+
+func cleanUpMapArray(in []Map) []Map {
+	result := make([]Map, len(in))
+	for i, v := range in {
+		result[i] = cleanUpStringMap(v)
+	}
+	return result
+}
+
+func cleanUp(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanUpInterfaceArray(v)
+	case []map[string]interface{}:
+		return cleanUpMSIArray(v)
+	case map[interface{}]interface{}:
+		return cleanUpInterfaceMap(v)
+	case Map:
+		return cleanUpStringMap(v)
+	case []Map:
+		return cleanUpMapArray(v)
+	default:
+		return v
+	}
 }
 
 // MustJSON converts the contained object to a JSON string

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -18,6 +18,36 @@ func TestConversionJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, jsonString, result)
 	assert.Equal(t, jsonString, o.MustJSON())
+
+	i := objx.Map{
+		"a": map[interface{}]interface{}{
+			"b": objx.Map{
+				"c": map[interface{}]interface{}{
+					"d": "e",
+				},
+			},
+			"f": []objx.Map{
+				objx.Map{
+					"g": map[interface{}]interface{}{
+						"h": "i",
+					},
+				},
+			},
+			"j": []map[string]interface{}{
+				map[string]interface{}{
+					"k": map[interface{}]interface{}{
+						"l": "m",
+					},
+				},
+			},
+		},
+	}
+
+	jsonString = `{"a":{"b":{"c":{"d":"e"}},"f":[{"g":{"h":"i"}}],"j":[{"k":{"l":"m"}}]}}`
+	result, err = i.JSON()
+	require.NoError(t, err)
+	assert.Equal(t, jsonString, result)
+	assert.Equal(t, jsonString, i.MustJSON())
 }
 
 func TestConversionJSONWithError(t *testing.T) {

--- a/type_specific.go
+++ b/type_specific.go
@@ -76,6 +76,20 @@ func (v *Value) IsMSISlice() bool {
 	_, ok := v.data.([]map[string]interface{})
 	if !ok {
 		_, ok = v.data.([]Map)
+		if !ok {
+			s, ok := v.data.([]interface{})
+			if ok {
+				for i := range s {
+					switch s[i].(type) {
+					case Map:
+					case map[string]interface{}:
+					default:
+						return false
+					}
+				}
+				return true
+			}
+		}
 	}
 	return ok
 }
@@ -241,7 +255,22 @@ func (v *Value) IsObjxMapSlice() bool {
 	_, ok := v.data.([](Map))
 	if !ok {
 		_, ok = v.data.([]map[string]interface{})
+		if !ok {
+			s, ok := v.data.([]interface{})
+			if ok {
+				for i := range s {
+					switch s[i].(type) {
+					case Map:
+					case map[string]interface{}:
+					default:
+						return false
+					}
+				}
+				return true
+			}
+		}
 	}
+
 	return ok
 }
 

--- a/type_specific_test.go
+++ b/type_specific_test.go
@@ -47,6 +47,13 @@ func TestMSISlice(t *testing.T) {
 	assert.Panics(t, func() {
 		m.Get("nothing").MustMSISlice()
 	})
+
+	o := objx.MustFromJSON(`{"d":[{"author":{"displayName":"DemoUser3","id":2},"classes":null,"id":9879,"v":{"code":"","created":"2013-09-19T09:38:50+02:00","published":"0001-01-01T00:00:00Z","updated":"2013-09-19T09:38:50+02:00"}}],"s":200}`)
+	assert.Equal(t, 9879, o.Get("d").MustMSISlice()[0]["id"])
+	assert.Equal(t, 1, len(o.Get("d").MSISlice()))
+
+	i := objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)
+	assert.Nil(t, i.Get("d").MSISlice())
 }
 
 func TestIsMSI(t *testing.T) {
@@ -62,6 +69,14 @@ func TestIsMSISlice(t *testing.T) {
 
 	assert.True(t, m.Get("data").IsMSISlice())
 	assert.True(t, m.Get("data2").IsMSISlice())
+
+	o := objx.MustFromJSON(`{"d":[{"author":{"displayName":"DemoUser3","id":2},"classes":null,"id":9879,"v":{"code":"","created":"2013-09-19T09:38:50+02:00","published":"0001-01-01T00:00:00Z","updated":"2013-09-19T09:38:50+02:00"}}],"s":200}`)
+	assert.True(t, o.Has("d"))
+	assert.True(t, o.Get("d").IsMSISlice())
+
+	o = objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)
+	assert.True(t, o.Has("d"))
+	assert.False(t, o.Get("d").IsMSISlice())
 }
 
 func TestEachMSI(t *testing.T) {
@@ -259,6 +274,13 @@ func TestObjxMapSlice(t *testing.T) {
 	assert.Panics(t, func() {
 		m.Get("nothing").MustObjxMapSlice()
 	})
+
+	o := objx.MustFromJSON(`{"d":[{"author":{"displayName":"DemoUser3","id":2},"classes":null,"id":9879,"v":{"code":"","created":"2013-09-19T09:38:50+02:00","published":"0001-01-01T00:00:00Z","updated":"2013-09-19T09:38:50+02:00"}}],"s":200}`)
+	assert.Equal(t, 9879, o.Get("d").MustObjxMapSlice()[0].Get("id").Int())
+	assert.Equal(t, 1, len(o.Get("d").ObjxMapSlice()))
+
+	i := objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)
+	assert.Nil(t, i.Get("d").ObjxMapSlice())
 }
 
 func TestIsObjxMap(t *testing.T) {
@@ -273,6 +295,15 @@ func TestIsObjxMapSlice(t *testing.T) {
 
 	assert.True(t, m.Get("data").IsObjxMapSlice())
 	assert.True(t, m.Get("data2").IsObjxMapSlice())
+
+	o := objx.MustFromJSON(`{"d":[{"author":{"displayName":"DemoUser3","id":2},"classes":null,"id":9879,"v":{"code":"","created":"2013-09-19T09:38:50+02:00","published":"0001-01-01T00:00:00Z","updated":"2013-09-19T09:38:50+02:00"}}],"s":200}`)
+	assert.True(t, o.Has("d"))
+	assert.True(t, o.Get("d").IsObjxMapSlice())
+
+	//Valid json but not MSI slice
+	o = objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)
+	assert.True(t, o.Has("d"))
+	assert.False(t, o.Get("d").IsObjxMapSlice())
 }
 
 func TestEachObjxMap(t *testing.T) {


### PR DESCRIPTION
If map[interface{}]interface{} end up within the Map, JSON() and MustJSON() fail even if the data is valid. Added methods to cleanup the data before converting to JSON