### PR TITLE
Fix for map[interface{}]interface{} to JSON conversion

### DIFF
--- a/conversions_test.go
+++ b/conversions_test.go
@@ -20,22 +20,9 @@ func TestConversionJSON(t *testing.T) {
 	assert.Equal(t, jsonString, o.MustJSON())
 
 	i := objx.Map{
-		"a": map[interface{}]interface{}{
-			"b": objx.Map{
-				"c": map[interface{}]interface{}{
-					"d": "e",
-				},
-			},
-			"f": []objx.Map{objx.Map{
-				"g": map[interface{}]interface{}{
-					"h": "i",
-				},
-			}},
-			"j": []map[string]interface{}{map[string]interface{}{
-				"k": map[interface{}]interface{}{
-					"l": "m",
-				},
-			}},
+		"a": map[interface{}]interface{}{"b": objx.Map{"c": map[interface{}]interface{}{"d": "e"}},
+			"f": []objx.Map{{"g": map[interface{}]interface{}{"h": "i"}}},
+			"j": []map[string]interface{}{{"k": map[interface{}]interface{}{"l": "m"}}},
 		},
 	}
 

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -18,6 +18,36 @@ func TestConversionJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, jsonString, result)
 	assert.Equal(t, jsonString, o.MustJSON())
+
+	i := objx.Map{
+		"a": map[interface{}]interface{}{
+			"b": objx.Map{
+				"c": map[interface{}]interface{}{
+					"d": "e",
+				},
+			},
+			"f": []objx.Map{
+				objx.Map{
+					"g": map[interface{}]interface{}{
+						"h": "i",
+					},
+				},
+			},
+			"j": []map[string]interface{}{
+				map[string]interface{}{
+					"k": map[interface{}]interface{}{
+						"l": "m",
+					},
+				},
+			},
+		},
+	}
+
+	jsonString = `{"a":{"b":{"c":{"d":"e"}},"f":[{"g":{"h":"i"}}],"j":[{"k":{"l":"m"}}]}}`
+	result, err = i.JSON()
+	require.NoError(t, err)
+	assert.Equal(t, jsonString, result)
+	assert.Equal(t, jsonString, i.MustJSON())
 }
 
 func TestConversionJSONWithError(t *testing.T) {

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -23,10 +23,11 @@ func TestConversionJSON(t *testing.T) {
 		"a": map[interface{}]interface{}{"b": objx.Map{"c": map[interface{}]interface{}{"d": "e"}},
 			"f": []objx.Map{{"g": map[interface{}]interface{}{"h": "i"}}},
 			"j": []map[string]interface{}{{"k": map[interface{}]interface{}{"l": "m"}}},
+			"n": []interface{}{objx.Map{"o": "p"}},
 		},
 	}
 
-	jsonString = `{"a":{"b":{"c":{"d":"e"}},"f":[{"g":{"h":"i"}}],"j":[{"k":{"l":"m"}}]}}`
+	jsonString = `{"a":{"b":{"c":{"d":"e"}},"f":[{"g":{"h":"i"}}],"j":[{"k":{"l":"m"}}],"n":[{"o":"p"}]}}`
 	result, err = i.JSON()
 	require.NoError(t, err)
 	assert.Equal(t, jsonString, result)

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -26,20 +26,16 @@ func TestConversionJSON(t *testing.T) {
 					"d": "e",
 				},
 			},
-			"f": []objx.Map{
-				objx.Map{
-					"g": map[interface{}]interface{}{
-						"h": "i",
-					},
+			"f": []objx.Map{objx.Map{
+				"g": map[interface{}]interface{}{
+					"h": "i",
 				},
-			},
-			"j": []map[string]interface{}{
-				map[string]interface{}{
-					"k": map[interface{}]interface{}{
-						"l": "m",
-					},
+			}},
+			"j": []map[string]interface{}{map[string]interface{}{
+				"k": map[interface{}]interface{}{
+					"l": "m",
 				},
-			},
+			}},
 		},
 	}
 


### PR DESCRIPTION
If map[interface{}]interface{} end up within the Map, JSON() and MustJSON() fail even if the data is valid. Added methods to cleanup the data before converting to JSON.