### PR TITLE
 Update to go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 install:
-  - wget https://github.com/go-task/task/releases/download/v2.0.1/task_linux_amd64.tar.gz
+  - wget https://github.com/go-task/task/releases/download/v2.5.0/task_linux_amd64.tar.gz
   - tar xf task_linux_amd64.tar.gz
   - mv task $HOME/gopath/bin
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - "1.9.x"
   - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
   - master
 
 matrix:


### PR DESCRIPTION
#### Summary
This PR uses go 1.12 for testing. It also update the readme.

#### Checklist
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
