### PR TITLE
Don't force upgrade to go 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stretchr/objx
 
-go 1.12
+go 1.11
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
<!-- Thank your for your contribution! Please fill out this template to help us review your PR-->

#### Summary
<!-- A brief description of what this pull request does -->
This repo makes my CI fail on go1.11

I'm not sure if this patch can fix it, just playing at this moment.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Tests are passing: `task test`
- [ ] Code style is correct: `task lint` 
I assumed PR checks would run tests and lint.
