### PR TITLE
Add helpers for slice of Map

### DIFF
--- a/map.go
+++ b/map.go
@@ -92,6 +92,18 @@ func MustFromJSON(jsonString string) Map {
 	return o
 }
 
+// MustFromJSONSlice creates a new slice of Map containing the data specified in the
+// jsonString. Works with jsons with a top level array
+//
+// Panics if the JSON is invalid.
+func MustFromJSONSlice(jsonString string) []Map {
+	slice, err := FromJSONSlice(jsonString)
+	if err != nil {
+		panic("objx: MustFromJSONSlice failed with error: " + err.Error())
+	}
+	return slice
+}
+
 // FromJSON creates a new Map containing the data specified in the
 // jsonString.
 //
@@ -104,6 +116,22 @@ func FromJSON(jsonString string) (Map, error) {
 	}
 	m.tryConvertFloat64()
 	return m, nil
+}
+
+// FromJSONSlice creates a new slice of Map containing the data specified in the
+// jsonString. Works with jsons with a top level array
+//
+// Returns an error if the JSON is invalid.
+func FromJSONSlice(jsonString string) ([]Map, error) {
+	var slice []Map
+	err := json.Unmarshal([]byte(jsonString), &slice)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range slice {
+		m.tryConvertFloat64()
+	}
+	return slice, nil
 }
 
 func (m Map) tryConvertFloat64() {

--- a/map_test.go
+++ b/map_test.go
@@ -225,3 +225,22 @@ func TestMapFromURLQueryWithError(t *testing.T) {
 		objx.MustFromURLQuery("%")
 	})
 }
+
+func TestJSONTopLevelSlice(t *testing.T) {
+	slice, err := objx.FromJSONSlice(`[{"id": 10000001}, {"id": 42}]`)
+
+	assert.NoError(t, err)
+	require.Len(t, slice, 2)
+	assert.Equal(t, 10000001, slice[0].Get("id").MustInt())
+	assert.Equal(t, 42, slice[1].Get("id").MustInt())
+}
+
+func TestJSONTopLevelSliceWithError(t *testing.T) {
+	slice, err := objx.FromJSONSlice(`{"id": 10000001}`)
+
+	assert.Error(t, err)
+	assert.Nil(t, slice)
+	assert.Panics(t, func() {
+		_ = objx.MustFromJSONSlice(`{"id": 10000001}`)
+	})
+}


### PR DESCRIPTION
#### Summary
objx can't work with JSON documents starting with top-level array. This
commit adds helpers FromJSONSlice and MustJSONSlice. Those returns `[]Map`
enabling objx usage for this case as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Tests are passing: `task test`
- [ ] Code style is correct: `task lint` 
