### PR TITLE
fix int to float conversions

### DIFF
--- a/map.go
+++ b/map.go
@@ -114,7 +114,6 @@ func FromJSON(jsonString string) (Map, error) {
 	if err != nil {
 		return Nil, err
 	}
-	m.tryConvertFloat64()
 	return m, nil
 }
 
@@ -128,47 +127,7 @@ func FromJSONSlice(jsonString string) ([]Map, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, m := range slice {
-		m.tryConvertFloat64()
-	}
 	return slice, nil
-}
-
-func (m Map) tryConvertFloat64() {
-	for k, v := range m {
-		switch v.(type) {
-		case float64:
-			f := v.(float64)
-			if float64(int(f)) == f {
-				m[k] = int(f)
-			}
-		case map[string]interface{}:
-			t := New(v)
-			t.tryConvertFloat64()
-			m[k] = t
-		case []interface{}:
-			m[k] = tryConvertFloat64InSlice(v.([]interface{}))
-		}
-	}
-}
-
-func tryConvertFloat64InSlice(s []interface{}) []interface{} {
-	for k, v := range s {
-		switch v.(type) {
-		case float64:
-			f := v.(float64)
-			if float64(int(f)) == f {
-				s[k] = int(f)
-			}
-		case map[string]interface{}:
-			t := New(v)
-			t.tryConvertFloat64()
-			s[k] = t
-		case []interface{}:
-			s[k] = tryConvertFloat64InSlice(v.([]interface{}))
-		}
-	}
-	return s
 }
 
 // FromBase64 creates a new Obj containing the data specified

--- a/map_test.go
+++ b/map_test.go
@@ -110,10 +110,10 @@ func TestConversionJSONInt(t *testing.T) {
 	assert.Equal(t, 1, m.Get("b.data").Int())
 
 	assert.True(t, m.Get("c").IsInterSlice())
-	assert.Equal(t, 1, m.Get("c").InterSlice()[0])
+	assert.Equal(t, float64(1), m.Get("c").InterSlice()[0])
 
 	assert.True(t, m.Get("d").IsInterSlice())
-	assert.Equal(t, []interface{}{1}, m.Get("d").InterSlice()[0])
+	assert.Equal(t, []interface{}{float64(1)}, m.Get("d").InterSlice()[0])
 }
 
 func TestJSONSliceInt(t *testing.T) {
@@ -128,7 +128,7 @@ func TestJSONSliceInt(t *testing.T) {
 
 	assert.Nil(t, err)
 	require.NotNil(t, m)
-	assert.Equal(t, []objx.Map{{"b": 1}, {"c": 2}}, m.Get("a").ObjxMapSlice())
+	assert.Equal(t, []objx.Map{{"b": float64(1)}, {"c": float64(2)}}, m.Get("a").ObjxMapSlice())
 }
 
 func TestJSONSliceMixed(t *testing.T) {

--- a/type_specific_codegen.go
+++ b/type_specific_codegen.go
@@ -385,6 +385,11 @@ func (v *Value) Int(optionalDefault ...int) int {
 	if s, ok := v.data.(int); ok {
 		return s
 	}
+	if s, ok := v.data.(float64); ok {
+		if float64(int(s)) == s {
+			return int(s)
+		}
+	}
 	if len(optionalDefault) == 1 {
 		return optionalDefault[0]
 	}
@@ -395,6 +400,11 @@ func (v *Value) Int(optionalDefault ...int) int {
 //
 // Panics if the object is not a int.
 func (v *Value) MustInt() int {
+	if s, ok := v.data.(float64); ok {
+		if float64(int(s)) == s {
+			return int(s)
+		}
+	}
 	return v.data.(int)
 }
 

--- a/type_specific_test.go
+++ b/type_specific_test.go
@@ -49,7 +49,7 @@ func TestMSISlice(t *testing.T) {
 	})
 
 	o := objx.MustFromJSON(`{"d":[{"author":{"displayName":"DemoUser3","id":2},"classes":null,"id":9879,"v":{"code":"","created":"2013-09-19T09:38:50+02:00","published":"0001-01-01T00:00:00Z","updated":"2013-09-19T09:38:50+02:00"}}],"s":200}`)
-	assert.Equal(t, 9879, o.Get("d").MustMSISlice()[0]["id"])
+	assert.Equal(t, float64(9879), o.Get("d").MustMSISlice()[0]["id"])
 	assert.Equal(t, 1, len(o.Get("d").MSISlice()))
 
 	i := objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)


### PR DESCRIPTION
<!-- Thank your for your contribution! Please fill out this template to help us review your PR-->
fixes https://github.com/stretchr/objx/issues/101
fixes https://github.com/stretchr/objx/issues/99

Due to https://github.com/stretchr/objx/pull/59 integer floats are converted to int, causing float check issues. One way to fix is to move float to int conversions to `Int()` accessor. This has the side effect of also fixing loss of precision. It also makes the implementation consistent with go's json unmarshal

#### Summary
<!-- A brief description of what this pull request does -->

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
