### PR TITLE
Fix typo in Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,6 @@ tasks:
       - go test -race  ./...
 
   test-coverage:
-    desc: Runs go tests and calucates test coverage
+    desc: Runs go tests and calculates test coverage
     cmds:
       - go test -race -coverprofile=c.out ./...


### PR DESCRIPTION
#### Summary
Fix a minor typo in the Taskfile.yml

Super minor change and you could do it yourself - just found it while searching for something else in one of our dependencies. I would propose fixing it.

#### Checklist
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
