### PR TITLE
Fix typos in comments and function names

### DIFF
--- a/accessors.go
+++ b/accessors.go
@@ -14,17 +14,17 @@ const (
 	// For example, `location.address.city`
 	PathSeparator string = "."
 
-	// arrayAccesRegexString is the regex used to extract the array number
+	// arrayAccessRegexString is the regex used to extract the array number
 	// from the access path
-	arrayAccesRegexString = `^(.+)\[([0-9]+)\]$`
+	arrayAccessRegexString = `^(.+)\[([0-9]+)\]$`
 
 	// mapAccessRegexString is the regex used to extract the map key
 	// from the access path
 	mapAccessRegexString = `^([^\[]*)\[([^\]]+)\](.*)$`
 )
 
-// arrayAccesRegex is the compiled arrayAccesRegexString
-var arrayAccesRegex = regexp.MustCompile(arrayAccesRegexString)
+// arrayAccessRegex is the compiled arrayAccessRegexString
+var arrayAccessRegex = regexp.MustCompile(arrayAccessRegexString)
 
 // mapAccessRegex is the compiled mapAccessRegexString
 var mapAccessRegex = regexp.MustCompile(mapAccessRegexString)
@@ -62,16 +62,16 @@ func (m Map) Set(selector string, value interface{}) Map {
 	return m
 }
 
-// getIndex returns the index, which is hold in s by two braches.
-// It also returns s withour the index part, e.g. name[1] will return (1, name).
+// getIndex returns the index, which is hold in s by two branches.
+// It also returns s without the index part, e.g. name[1] will return (1, name).
 // If no index is found, -1 is returned
 func getIndex(s string) (int, string) {
-	arrayMatches := arrayAccesRegex.FindStringSubmatch(s)
+	arrayMatches := arrayAccessRegex.FindStringSubmatch(s)
 	if len(arrayMatches) > 0 {
 		// Get the key into the map
 		selector := arrayMatches[1]
 		// Get the index into the array at the key
-		// We know this cannt fail because arrayMatches[2] is an int for sure
+		// We know this can't fail because arrayMatches[2] is an int for sure
 		index, _ := strconv.Atoi(arrayMatches[2])
 		return index, selector
 	}

--- a/conversions.go
+++ b/conversions.go
@@ -15,7 +15,7 @@ import (
 const SignatureSeparator = "_"
 
 // URLValuesSliceKeySuffix is the character that is used to
-// specify a suffic for slices parsed by URLValues.
+// specify a suffix for slices parsed by URLValues.
 // If the suffix is set to "[i]", then the index of the slice
 // is used in place of i
 // Ex: Suffix "[]" would have the form a[]=b&a[]=c
@@ -30,7 +30,7 @@ const (
 )
 
 // SetURLValuesSliceKeySuffix sets the character that is used to
-// specify a suffic for slices parsed by URLValues.
+// specify a suffix for slices parsed by URLValues.
 // If the suffix is set to "[i]", then the index of the slice
 // is used in place of i
 // Ex: Suffix "[]" would have the form a[]=b&a[]=c

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
-Objx - Go package for dealing with maps, slices, JSON and other data.
+Package objx provides utilities for dealing with maps, slices, JSON and other data.
 
 Overview
 
@@ -10,7 +10,7 @@ missing data, default values etc.
 
 Pattern
 
-Objx uses a preditable pattern to make access data from within `map[string]interface{}` easy.
+Objx uses a predictable pattern to make access data from within `map[string]interface{}` easy.
 Call one of the `objx.` functions to create your `objx.Map` to get going:
 
     m, err := objx.FromJSON(json)

--- a/map_test.go
+++ b/map_test.go
@@ -62,7 +62,7 @@ func TestMapCreation(t *testing.T) {
 	assert.Nil(t, o)
 }
 
-func TestMapValure(t *testing.T) {
+func TestMapValue(t *testing.T) {
 	m := objx.Map{
 		"a": 1,
 	}

--- a/type_specific_test.go
+++ b/type_specific_test.go
@@ -300,7 +300,7 @@ func TestIsObjxMapSlice(t *testing.T) {
 	assert.True(t, o.Has("d"))
 	assert.True(t, o.Get("d").IsObjxMapSlice())
 
-	//Valid json but not MSI slice
+	// Valid json but not MSI slice
 	o = objx.MustFromJSON(`{"d":[{"author":"abc"},[1]]}`)
 	assert.True(t, o.Has("d"))
 	assert.False(t, o.Get("d").IsObjxMapSlice())


### PR DESCRIPTION
#### Summary
This PR fixes comments format, typos in comments and functions.

#### Change Details

Fixes the following doc issues:
- Package comment should start with `package PACKAGE_NAME` according to the [doc](https://go.dev/doc/comment#packages).
- After `//` there should be a whitespace.
- Different typos in words.

#### Checklist
- [] Tests are passing: `task test`
- [] Code style is correct: `task lint` 
