### PR TITLE
Use go1.20; update .github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.1', '1.17.6', '1.16.5' ]
+        go: [ '1.20.2',  '1.19.7',  '1.18.10', '1.17.13', '1.16.15' ]
     steps:
     - uses: actions/checkout@v3
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/stretchr/objx
 
-go 1.13
+go 1.20
 
 require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
#### Summary
Upgrade go module version to go version supported by the go lang team
This PR:

- updates go.mod to use go 1.20
- changes go versions in github actions
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Tests are passing: `task test`
- [ ] Code style is correct: `task lint` 

```
[:~/enjoy/objx][update-go-version]
$ go test 
PASS
ok      github.com/stretchr/objx        0.424s
```
