### PR TITLE
Rewrite Accessor to fix array access issues, also add a Delete method

### DIFF
--- a/accessors.go
+++ b/accessors.go
@@ -68,6 +68,15 @@ func (m Map) Has(selector string) bool {
 	return err == nil
 }
 
+// Deletes the value from the element
+// Note: Array elements can not be deleted, they will only be set null
+// Returns the old element or nil if it did not exist
+func (m Map) Delete(selector string) *Value {
+	val := reflect.ValueOf(nil)
+	res, _ := access(m, selector, &val, false)
+	return &Value{data: res}
+}
+
 func parsePath(path string) ([]string, error) {
 	res := make([]string, 0, 8)
 	path = strings.TrimPrefix(path, ".")

--- a/accessors.go
+++ b/accessors.go
@@ -56,6 +56,18 @@ func (m Map) Set(selector string, value interface{}) Map {
 	return m
 }
 
+// Has gets whether there is something at the specified selector
+// or not.
+//
+// If m is nil, Has will always return false.
+func (m Map) Has(selector string) bool {
+	if m == nil {
+		return false
+	}
+	_, err := access(m, selector, nil, false)
+	return err == nil
+}
+
 func parsePath(path string) ([]string, error) {
 	res := make([]string, 0, 8)
 	path = strings.TrimPrefix(path, ".")

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -384,3 +384,48 @@ func TestGenericDeepNull(t *testing.T) {
 	assert.Equal(t, `{"nope":null,"null":null}`, json)
 }
 
+func TestGenericDeepDeleteNested(t *testing.T) {
+	m := objx.Map{}
+
+	m.Set("other[0].x", "e0")
+	m.Set("other[1].x", "e1")
+	m.Set("other[2].x", "e2")
+
+	assert.Equal(t, nil, m.Delete("a.b").Data())
+	assert.Equal(t, "e0", m.Delete("other[0].x").Data())
+	assert.Equal(t, map[string]interface{}{"x": "e1"}, m.Delete("other[1]").Data())
+
+	json, err := m.JSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"other":[{},null,{"x":"e2"}]}`, json)
+}
+
+func TestGenericDeepDeleteArrayShrink(t *testing.T) {
+	m := objx.Map{}
+
+	m.Set("other[0].x", "e0")
+	m.Set("other[1].x", "e1")
+
+	assert.Equal(t, "e0", m.Delete("other[0].x").Data())
+	assert.Equal(t, map[string]interface{}{"x": "e1"}, m.Delete("other[1]").Data())
+
+	json, err := m.JSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"other":[{},null]}`, json)
+}
+
+func TestGenericDeepDeleteAll(t *testing.T) {
+	m := objx.Map{}
+
+	m.Set("other[0].x", "e0")
+	m.Set("other[1].x", "e1")
+
+	assert.Equal(t, []interface{}{
+		map[string]interface{}{"x": "e0"},
+		map[string]interface{}{"x": "e1"},
+	}, m.Delete("other").Data())
+
+	json, err := m.JSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `{}`, json)
+}

--- a/accessors_test.go
+++ b/accessors_test.go
@@ -366,3 +366,21 @@ func TestGenericDeepPrimitives(t *testing.T) {
 	assert.Equal(t, `{"arr":[],"boolean":true,"float":1.1,"int":1,"null":null,"obj":{},"str":"str"}`, json)
 }
 
+func TestGenericDeepNull(t *testing.T) {
+	m := objx.MustFromJSON(`{"nope":null}`)
+
+	m.Set("null", nil)
+
+	assert.Equal(t, true, m.Has("nope"))
+	assert.Equal(t, true, m.Has("null"))
+	assert.Equal(t, false, m.Has("no-exist"))
+
+	assert.Equal(t, nil, m.Get("nope").Data())
+	assert.Equal(t, nil, m.Get("null").Data())
+	assert.Equal(t, nil, m.Get("no-exist").Data())
+
+	json, err := m.JSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"nope":null,"null":null}`, json)
+}
+

--- a/tests.go
+++ b/tests.go
@@ -1,16 +1,5 @@
 package objx
 
-// Has gets whether there is something at the specified selector
-// or not.
-//
-// If m is nil, Has will always return false.
-func (m Map) Has(selector string) bool {
-	if m == nil {
-		return false
-	}
-	return !m.Get(selector).IsNil()
-}
-
 // IsNil gets whether the data is nil or not.
 func (v *Value) IsNil() bool {
 	return v == nil || v.data == nil


### PR DESCRIPTION
#### Summary
This is a rewrite of the accessor code to fix a lot of issues with access to arrays.

I added some tests that were failing bevor this rewrite.

There should be no breaking changes with this code.
However the new code could allow errors to be forwarded to the caller.
e.g. for Get() to differentiate between not found and json null value.
Or to notify the caller about an invalid path expression.

Maybe add new methods for this?

In this PR all errors are just swallowed to keep compatibility.

Additionally a new Delete method is introduced which was trivial to add with the new code.

#### Checklist
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
