### PR TITLE
Extend test coverage to include go 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22', '1.21', '1.20' ]
+        go: [ '1.25', '1.24', '1.23', '1.22', '1.21', '1.20' ]
     steps:
     - uses: actions/checkout@v5
 


### PR DESCRIPTION
#### Summary
Test go1.25, go1.24 and go1.23 in CI

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
