### PR TITLE
Remove duplicate module cache from CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,16 +24,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Setup go module cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Lint
       run: diff -u <(echo -n) <(task lint)
 


### PR DESCRIPTION
#### Summary
The setup-go action now takes care of that: https://github.com/actions/setup-go/tree/v6/?tab=readme-ov-file#caching-dependency-files-and-build-outputs

#### Checklist
- [x] Tests are passing: `task test`
- [x] Code style is correct: `task lint` 
