### PR TITLE
test: add TestValue_IsNil in tests_test.go

### DIFF
--- a/tests_test.go
+++ b/tests_test.go
@@ -22,3 +22,23 @@ func TestHas(t *testing.T) {
 
 	assert.False(t, m.Has("nothing"))
 }
+
+func TestValue_IsNil(t *testing.T) {
+	var nilVal *objx.Value
+	assert.True(t, nilVal.IsNil())
+
+	m := objx.Map{
+		"nil":  nil,
+		"str":  "hello",
+		"int":  123,
+		"bool": true,
+	}
+
+	assert.True(t, m.Get("nil").IsNil())
+	assert.True(t, m.Get("nonexistent").IsNil())
+	assert.False(t, m.Get("str").IsNil())
+	assert.False(t, m.Get("int").IsNil())
+	assert.False(t, m.Get("bool").IsNil())
+}
+
+


### PR DESCRIPTION
### Summary
- Add `TestValue_IsNil` in `tests_test.go` to test `Value.IsNil()` for untyped nil pointers, explicit nil data inside map values, non-existent keys, and populated primitive values.